### PR TITLE
Use fmin and fmax

### DIFF
--- a/pyfasttextureutils.c
+++ b/pyfasttextureutils.c
@@ -240,8 +240,8 @@ static PyObject* pyfasttextureutils_color_exchange(PyObject* self, PyObject* arg
       v += v_change;
       
       h %= 360;
-      s = max(0, min(100, s));
-      v = max(0, min(100, v));
+      s = fmax(0, fmin(100, s));
+      v = fmax(0, fmin(100, v));
       
       pyfasttextureutils_hsv_to_rgb(h, s, v, &r, &g, &b);
     }


### PR DESCRIPTION
Uses `fmin` and `fmax` in place of `min` and `max`. Fixes building on macOS CI.